### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A secure Model Context Protocol (MCP) server that bridges Claude Code with OpenAI and Google Gemini APIs.
 
+<a href="https://glama.ai/mcp/servers/@fakoli/mcp-ai-bridge">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@fakoli/mcp-ai-bridge/badge" alt="AI Bridge MCP server" />
+</a>
+
 ## Features
 
 - **OpenAI Integration**: Access GPT-4, GPT-4 Turbo, and GPT-3.5 Turbo models


### PR DESCRIPTION
This PR adds a badge for the [MCP AI Bridge](https://glama.ai/mcp/servers/@fakoli/mcp-ai-bridge) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@fakoli/mcp-ai-bridge">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@fakoli/mcp-ai-bridge/badge" alt="AI Bridge MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.