### PR TITLE
Update README.md with correct model information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 # Temporary files
 .tmp/
 temp/
+
+# Claude directories
+.claude/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A secure Model Context Protocol (MCP) server that bridges Claude Code with OpenA
 
 ## Features
 
-- **OpenAI Integration**: Access GPT-4, GPT-4 Turbo, and GPT-3.5 Turbo models
+- **OpenAI Integration**: Access GPT-4o, GPT-4o Mini, GPT-4 Turbo, GPT-4, and GPT-3.5 Turbo models
 - **Gemini Integration**: Access Gemini Pro, Gemini 1.5 Pro, and Gemini 1.5 Flash models
 - **Security Features**: 
   - Input validation and sanitization
@@ -51,7 +51,7 @@ npm install
 
 The server will check for environment variables in this order:
 1. `~/.env` (your home directory)
-2. `./env` (local to mcp-ai-bridge directory)
+2. `./.env` (local to mcp-ai-bridge directory)
 3. System environment variables
 
 4. **Optional Configuration Variables**:
@@ -129,7 +129,7 @@ Query OpenAI models with full validation and security features.
 
 Parameters:
 - `prompt` (required): The question or prompt to send (max 10,000 characters)
-- `model` (optional): Choose from 'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', or 'gpt-3.5-turbo'
+- `model` (optional): Choose from 'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', or 'gpt-3.5-turbo' (default: 'gpt-4o-mini')
 - `temperature` (optional): Control randomness (0-2, default: 0.7)
 
 Security Features:
@@ -143,7 +143,7 @@ Query Google Gemini models with full validation and security features.
 
 Parameters:
 - `prompt` (required): The question or prompt to send (max 10,000 characters)
-- `model` (optional): Choose from 'gemini-pro', 'gemini-1.5-pro', or 'gemini-1.5-flash'
+- `model` (optional): Choose from 'gemini-pro', 'gemini-1.5-pro', or 'gemini-1.5-flash' (default: 'gemini-pro')
 - `temperature` (optional): Control randomness (0-1, default: 0.7)
 
 Security Features:


### PR DESCRIPTION
## Summary
- Updated OpenAI models list to include GPT-4o and GPT-4o Mini models that are actually available in the codebase
- Added default model information for both OpenAI (gpt-4o-mini) and Gemini (gemini-pro) services
- Fixed typo in environment loading order documentation (./env → ./.env)
- Aligned documentation with actual implementation in constants.js

## Changes Made
- Line 11: Updated OpenAI integration description to include all available models
- Line 54: Fixed typo in .env file path documentation  
- Line 132: Added default model info for OpenAI tools
- Line 146: Added default model info for Gemini tools

## Test plan
- [x] Verified all model names match those defined in src/constants.js
- [x] Confirmed default models match DEFAULTS configuration
- [x] Checked that .env path correction aligns with actual code behavior

🤖 Generated with [Claude Code](https://claude.ai/code)